### PR TITLE
jest-stare Results Processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 - [jest-skipped-reporter](https://github.com/rickhanlonii/jest-skipped-reporter) Report skipped tests in Jest.
 
 ### Results Processors
-- [jest-stare](https://github.com/dkelosky/jest-stare) HTML results viewer filters on passing or failing tests, saves raw JSON test results, and shows side-by-side snapshot diffs.
+- [jest-stare](https://github.com/dkelosky/jest-stare) Configurable HTML results processor for filtering, side-by-side snapshot diffs, API, and simple CLI.
 
 ### Environments
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 - [jest-skipped-reporter](https://github.com/rickhanlonii/jest-skipped-reporter) Report skipped tests in Jest.
 
 ### Results Processors
-- [jest-stare](https://github.com/dkelosky/jest-stare) HTML results viewer for Jest.
+- [jest-stare](https://github.com/dkelosky/jest-stare) HTML results viewer filters on passing or failing tests, saves raw JSON test results, and shows side-by-side snapshot diffs.
 
 ### Environments
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   * [Linting](#linting)
   * [Runners](#runners)
   * [Reporters](#reporters)
+  * [Results Processors](#results-processors)
   * [Environments](#environments)
   * [Snapshot](#snapshot)
   * [Migration](#migration)
@@ -45,11 +46,13 @@
 - [jest-runner-mocha](https://github.com/rogeliog/jest-runner-mocha) Mocha runner for Jest.
 - [jest-runner-prettier](https://github.com/keplersj/jest-runner-prettier) Prettier runner for Jest.
 
-
 ### Reporters
 
 - [jest-silent-reporter](https://github.com/rickhanlonii/jest-silent-reporter) A silent reporter for Jest.
 - [jest-skipped-reporter](https://github.com/rickhanlonii/jest-skipped-reporter) Report skipped tests in Jest.
+
+### Results Processors
+- [jest-stare](https://github.com/dkelosky/jest-stare) HTML results viewer for Jest.
 
 ### Environments
 


### PR DESCRIPTION
After switching testing frameworks from Mocha to Jest, I wanted a similar way to view and filter test results within an HTML file.  Existing Jest HTML results processors work fine but do not show a modern looking UI and cannot filter on "pass" or "fail" tests.

[jest-stare](https://github.com/dkelosky/jest-stare) is a Jest "results processor" is an attempt to recreate a [mochawesome](https://github.com/adamgruber/mochawesome) like report for Jest.  


