### PR TITLE
Move jest-stare to Reporter Instead of Results Processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 - [jest-stare](https://github.com/dkelosky/jest-stare) Configurable HTML reporter for filtering, side-by-side snapshot diffs, API, and simple CLI.
 
 ### Results Processors
+
 - [majestic](https://github.com/Raathigesh/majestic) Zero config UI for Jest.
 
 ### Environments

--- a/README.md
+++ b/README.md
@@ -56,12 +56,11 @@
 
 - [jest-silent-reporter](https://github.com/rickhanlonii/jest-silent-reporter) A silent reporter for Jest.
 - [jest-skipped-reporter](https://github.com/rickhanlonii/jest-skipped-reporter) Report skipped tests in Jest.
-- [jest-html-reporter](https://github.com/Hargne/jest-html-reporter)  A Jest test results processor for generating a summary in HTML. 
+- [jest-html-reporter](https://github.com/Hargne/jest-html-reporter)  A Jest test results processor for generating a summary in HTML.
+- [jest-stare](https://github.com/dkelosky/jest-stare) Configurable HTML reporter for filtering, side-by-side snapshot diffs, API, and simple CLI.
 
 ### Results Processors
-
 - [majestic](https://github.com/Raathigesh/majestic) Zero config UI for Jest.
-- [jest-stare](https://github.com/dkelosky/jest-stare) Configurable HTML results processor for filtering, side-by-side snapshot diffs, API, and simple CLI.
 
 ### Environments
 


### PR DESCRIPTION
It seems like results processors are being deprecated and "jest-stare" handles being run as a reporter, so I'd like to move the reference to this project under the non-deprecated term.