### PR TITLE
adding jest-slow-test-reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 - [jest-skipped-reporter](https://github.com/rickhanlonii/jest-skipped-reporter) Report skipped tests in Jest.
 - [jest-html-reporter](https://github.com/Hargne/jest-html-reporter)  A Jest test results processor for generating a summary in HTML.
 - [jest-stare](https://github.com/dkelosky/jest-stare) Configurable HTML reporter for filtering, side-by-side snapshot diffs, API, and simple CLI.
+- [jest-slow-test-reporter](https://github.com/jodonnell/jest-slow-test-reporter) Prints the slowest tests in your codebase.
 
 ### Results Processors
 


### PR DESCRIPTION
No dependencies, no interactive shell needed.  Prints out the slowest 10 tests in your app.  Can also print warnings when a test exceeds X ms.