### PR TITLE
Add jest-shell-matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - [expect-puppeteer](https://github.com/smooth-code/jest-puppeteer/tree/master/packages/expect-puppeteer) Collection of matchers for Jest & Puppeteer.
 - [jest-dom](https://github.com/gnapse/jest-dom) Custom Jest matchers to test the dom structure.
 - [jest-generator](https://github.com/doniyor2109/jest-generator) Jest matcher for testing generator function.
+- [jest-shell-matchers](https://github.com/raingerber/jest-shell-matchers) Test shell scripts while mocking specific commands.
 
 ### IDE
 


### PR DESCRIPTION
[jest-shell-matchers](https://github.com/raingerber/jest-shell-matchers) adds support for unit testing shell scripts, while also using Jest to mock specific commands. For example, you could mock ```curl``` to prevent network requests. Like any mock, you can also define the output and make assertions about the input.