### PR TITLE
Added a link to `eslint-plugin-jest-formatting`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 ### Linting
 
 - [eslint-plugin-jest](https://www.github.com/jest-community/eslint-plugin-jest) ESLint plugin for Jest.
+- [eslint-plugin-jest-formatting](https://github.com/dangreenisrael/eslint-plugin-jest-formatting)
 
 ### Runners
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 ### Linting
 
 - [eslint-plugin-jest](https://www.github.com/jest-community/eslint-plugin-jest) ESLint plugin for Jest.
-- [eslint-plugin-jest-formatting](https://github.com/dangreenisrael/eslint-plugin-jest-formatting)
+- [eslint-plugin-jest-formatting](https://github.com/dangreenisrael/eslint-plugin-jest-formatting) ESLint plugin that aims to provide formatting rules (auto-fixable where possible) to ensure consistency and readability in jest test suites.
 
 ### Runners
 


### PR DESCRIPTION
This PR adds a link to the `eslint-plugin-jest-formatting` repo.

This project aims to provide formatting rules (auto-fixable where possible) to ensure consistency and readability in jest test suites.