### PR TITLE
Add reference to node-recorder's watch plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@
 - [jest-watch-toggle-config](https://github.com/jest-community/jest-watch-toggle-config) Toggle boolean settings (e.g. verbosity, test coverage).
 - [jest-watch-typeahead](https://github.com/jest-community/jest-watch-typeahead) Filter your tests by file name or test name.
 - [jest-watch-yarn-workspaces](https://github.com/cameronhunter/jest-watch-directories/tree/master/packages/jest-watch-yarn-workspaces) Select Yarn workspaces to test.
+- [node-recorder](https://github.com/ericclemmons/node-recorder/#using-jest) Toggle recording modes for `node-recorder`.
 
 ### Processor
 


### PR DESCRIPTION
[`node-recorder`](https://github.com/ericclemmons/node-recorder/#using-jest) has a Jest watch plugin that toggles recording modes:
> ![](https://raw.githubusercontent.com/ericclemmons/node-recorder/master/demo.gif)