### PR TITLE
feat: add url-loader, less-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@
 - [marko-jest](https://github.com/abiyasa/marko-jest) Processor for [Marko component](https://markojs.com/).
 - [awesome-pug-jest](https://github.com/iketari/awesome-pug-jest) Processor for [Pug/Jade](https://pugjs.org/)
 - [jest-raw-loader](https://github.com/keplersj/jest-raw-loader) Processor mimicking `webpack`'s `raw-loader`.
+- [jest-less-loader](https://github.com/hustcc/jest-less-loader) Jest transformer for `.less` file.
+- [jest-url-loader](https://github.com/hustcc/jest-url-loader) Similar with webpack's `url-loader` for Jest transformer.
 
 ### Presets
 


### PR DESCRIPTION
- [jest-less-loader](https://github.com/hustcc/jest-less-loader) Jest transformer for `.less` file.
- [jest-url-loader](https://github.com/hustcc/jest-url-loader) Similar with webpack's `url-loader` for Jest transformer.