### PR TITLE
Add jest-runner-groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 - [jest-runner-prettier](https://github.com/keplersj/jest-runner-prettier) Prettier runner for Jest.
 - [jest-electron-runner](https://github.com/d4rkr00t/jest-electron-runner) Electron runner for Jest.
 - [jest-runner-stylelint](https://github.com/keplersj/jest-runner-stylelint) Stylelint runner for Jest.
+- [jest-runner-groups](https://github.com/eugene-manuilov/jest-runner-groups) A runner that lets to group tests and to run groups separately.
 
 ### Reporters
 


### PR DESCRIPTION
**jest-runner-groups** is a custom runner that allows engineers to tag tests and execute groups of tests.

Repo: https://github.com/eugene-manuilov/jest-runner-groups