### PR TITLE
Add jest-runner-vscode

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
 - [jest-electron-runner](https://github.com/d4rkr00t/jest-electron-runner) Electron runner for Jest.
 - [jest-runner-stylelint](https://github.com/keplersj/jest-runner-stylelint) Stylelint runner for Jest.
 - [jest-runner-groups](https://github.com/eugene-manuilov/jest-runner-groups) A runner that lets to group tests and to run groups separately.
+- [jest-runner-vscode](https://github.com/bmealhouse/jest-runner-vscode) VS Code extension test runner for Jest.
 
 ### Reporters
 


### PR DESCRIPTION
Mocha is the only documented test runner for building VS Code extensions so I'm working with the VS Code team to have Jest documented as well (https://github.com/microsoft/vscode-docs/issues/3363).

In that process, I found this awesome list and figured I would add [jest-runner-vscode](https://github.com/bmealhouse/jest-runner-vscode).

Please let me know if you have any questions.