### PR TITLE
Add jest-openapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 - [jest-generator](https://github.com/doniyor2109/jest-generator) Jest matcher for testing generator function.
 - [jest-shell-matchers](https://github.com/raingerber/jest-shell-matchers) Test shell scripts while mocking specific commands.
 - [jest-emotion](https://github.com/emotion-js/emotion/tree/master/packages/jest-emotion) Jest matcher for testing Emotion components.
+- [jest-openapi](https://github.com/RuntimeTools/OpenAPIValidators/tree/master/packages/jest-openapi) Jest matchers for asserting that HTTP responses satisfy an [OpenAPI](https://swagger.io/docs/specification/about) spec.
 
 ### IDE
 


### PR DESCRIPTION
[`jest-openapi`](https://github.com/RuntimeTools/OpenAPIValidators/tree/master/packages/jest-openapi) lets you automatically test whether your server's behaviour and documentation match. It adds Jest matchers that support the [OpenAPI standard](https://swagger.io/docs/specification/about/) for documenting REST APIs. You can simply assert `expect(responseObject).toSatisfyApiSpec()`