### PR TITLE
Add jest-it-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   * [Reporters](#reporters)
   * [Results Processors](#results-processors)
   * [Environments](#environments)
+  * [Coverage](#coverage)
   * [Snapshot](#snapshot)
   * [Migration](#migration)
   * [Library extensions](#library-extensions)
@@ -82,6 +83,8 @@
 
 - [jest-environment-webdriver](https://github.com/alexeyraspopov/jest-webdriver) custom environment for WebDriver integration.
 - [jest-environment-puppeteer](https://github.com/smooth-code/jest-puppeteer/tree/master/packages/jest-environment-puppeteer) Puppeteer environment for Jest.
+
+### Coverage
 
 ### Snapshot
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@
 
 ### Coverage
 
+- [jest-it-up](https://github.com/rbardini/jest-it-up) Automatically bump up global thresholds whenever coverage goes above them.
+
 ### Snapshot
 
 - [snapshot-diff](https://www.github.com/jest-community/snapshot-diff) Takes two values, and return their difference as a string, ready to be snapshotted with toMatchSnapshot(). Especially helpful when testing the difference between different React component states.


### PR DESCRIPTION
[jest-it-up](https://github.com/rbardini/jest-it-up) ensures incremental coverage gains are not lost by automatically bumping up global Jest thresholds whenever coverage goes above them.

I've added it under a new _Coverage_ category before _Snapshot_, as I didn't find an appropriate category for this package, but let me know if you have a better suggestion.