### PR TITLE
Add jest-os-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@
 - [@bigtest/interactor](https://www.bigtestjs.io/guides/interactors/introduction/) Composable Page Objects for component based applications. Checkout the [documentation](https://www.bigtestjs.io/guides/interactors/introduction/) and [blog post](https://medium.com/@robdel12/jest-bigtest-interactor-component-test-%EF%B8%8F-11b1947954c8) about using with Jest.
 - [@testdeck/jest](https://github.com/testdeck/testdeck/) Decorator based wrapper around Jest for object oriented testing. Checkout the [documentation](https://testdeck.org) and a working [seed](https://github.com/testdeck/testdeck-jest-seed) for you to start with.
 - [jest-plugin-must-assert](https://github.com/ballercat/jest-plugin-must-assert) A Jest plugin for strict runtime checks. Fails any tests without assertions and prevents async tasks (Promises & timeouts) from leaking across tests.
+- [jest-os-detection](https://github.com/doctolib/jest-os-detection) Dynamically enable or skip tests based on the OS they run on so you can share the same test suite accross various platforms.
 
 ### Mocks
 


### PR DESCRIPTION
[jest-os-detection](https://github.com/doctolib/jest-os-detection) allows to merge the test suites you use on various platforms. For instance:
```js
describe.onWindows('would be skipped on anything different than Windows', () => {})
it.onLinux.each([])('Every test would only run on Linux', () => {})
```