### PR TITLE
Added jest-runner-tsc to "runners" section on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 - [jest-electron-runner](https://github.com/d4rkr00t/jest-electron-runner) Electron runner for Jest.
 - [jest-runner-stylelint](https://github.com/keplersj/jest-runner-stylelint) Stylelint runner for Jest.
 - [jest-runner-groups](https://github.com/eugene-manuilov/jest-runner-groups) A runner that lets to group tests and to run groups separately.
+- [jest-runner-tsc](https://github.com/azz/jest-runner-tsc) A Jest runner for the TypeScript compiler. 
 
 ### Reporters
 


### PR DESCRIPTION
Added [jest-runner-tsc](https://github.com/azz/jest-runner-tsc). It is listed on Jest's site as an [available runner](https://github.com/azz/jest-runner-tsc).  