### PR TITLE
Added jest-coverage-thresholds-bumper under "coverage" category

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@
 ### Coverage
 
 - [jest-it-up](https://github.com/rbardini/jest-it-up) Automatically bump up global thresholds whenever coverage goes above them.
+- [jest-coverage-thresholds-bumper](https://github.com/Litee/jest-coverage-thresholds-bumper) Similar to `jest-it-up`, but allows to specify where coverage summary is located, supports Jest config in JSON files and `package.json`.
 
 ### Snapshot
 


### PR DESCRIPTION
Hi,

I have created `jest-coverage-thresholds-bumper` package for my team some time ago to make sure that code coverage never goes down without people looking into it. It is similar to `jest-it-up` package (it looks like both packages were developed at the same time), but it has extra features that `jest-it-up` is missing.