### PR TITLE
Add reporter testrail-jest-reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
 - [jest-github-reporter](https://github.com/hipstersmoothie/jest-github-reporter) Report jest test errors directly in pull requests
 - [jest-email-reporter](https://github.com/tglink/jest-email-reporter) Reporter for jest test errors by e-mail
 - [jest-dashboard](https://github.com/theoutlander/jest-dashboard) Command line dashboard
+- [testrail-jest-reporter](https://github.com/AntonChaukin/testrail-jest-reporter) Report jest test results to TestRail
 ### Results Processors
 
 - [majestic](https://github.com/Raathigesh/majestic) Zero config UI for Jest.


### PR DESCRIPTION
This Reporter uses versions by TestRail Milestone and adds test results to test Runs that already exist in TestRail, and does not create new ones each time Jest runs, like other Jest to TestRail packages