### PR TITLE
Add 1log

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@
 - [jest-serializer-json-ld-script](https://github.com/keplersj/jest-serializer-json-ld-script) Serializes JSON+LD elements as JavaScript objects.
 - [jest-emotion](https://github.com/emotion-js/emotion/tree/master/packages/jest-emotion) Include Emotion styles in component snapshots.
 - [jest-serializer-xml](https://github.com/keplersj/jest-serializer-xml) Format XML documents to better visualize in Snapshots.
+- [1log](https://github.com/ivan7237d/1log) Extensible logger that allows capturing log messages as snapshots.
 
 ### Migration
 


### PR DESCRIPTION
[1log](https://github.com/ivan7237d/1log) is a logging utility that among other things, lets you inspect log messages in tests, and provides a custom snapshot serializer to make sure the snapshots are easy to read. You can see a sample test in section [Using log snapshots in tests](https://github.com/ivan7237d/1log#using-log-snapshots-in-tests) of the README.