### PR TITLE
Add jest-json

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 - [jest-shell-matchers](https://github.com/raingerber/jest-shell-matchers) Test shell scripts while mocking specific commands.
 - [jest-emotion](https://github.com/emotion-js/emotion/tree/master/packages/jest-emotion) Jest matcher for testing Emotion components.
 - [jest-openapi](https://github.com/openapi-library/OpenAPIValidators/tree/master/packages/jest-openapi) Jest matchers for asserting that HTTP responses satisfy an [OpenAPI](https://swagger.io/docs/specification/about) spec.
+- [jest-json](https://github.com/duailibe/jest-json) Jest matchers to assert on JSON strings.
 
 ### IDE
 


### PR DESCRIPTION
It may look similar to [jest-json-matcher](https://github.com/americanexpress/jest-json-schema), but jest-json matchers make assertions on the contents of a JSON string; jest-json-matchers asserts that a JS object is of a given schema.