### PR TITLE
Add `jest-preview`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   - [Processor](#processor)
   - [Presets](#presets)
   - [Generators](#generators)
+  - [Debug](#debug)
 - [Resources](#resources)
 
 ## Packages
@@ -182,6 +183,10 @@
 ### Generators
 
 - [jest-test-gen](https://github.com/egm0121/jest-test-gen) CLI tool to generate a test file with test scaffold for every class method or function exported.
+
+### Debug
+
+- [jest-preview](https://github.com/nvh95/jest-preview) Preview Jest tests in a browser.
 
 ## Resources
 


### PR DESCRIPTION
# Motivation
When debugging a Jest test (e.g: React), it's extremely difficult to imagine what the UI looks like in your head. [jest-preview](https://github.com/nvh95/jest-preview) helps to preview the UI of your app in Jest to an external browser (such as Chrome), increasing productivity when debugging or writing new tests.

# Demo
![Jest Preview Demo](https://user-images.githubusercontent.com/8603085/162563155-7e18c9ef-4fe3-45f2-9065-7fcea8ddb18e.gif)

# Online playground
https://stackblitz.com/edit/jest-preview?file=README.md

# GitHub
https://github.com/nvh95/jest-preview

# Documentation
https://www.jest-preview.com/docs/getting-started/intro
