### PR TITLE
Add jest-wip-reporter to the README's list of reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@
 - [jest-ci-spec-reporter](https://github.com/robertbradleyux/jest-ci-spec-reporter) Zero dependency spec reporter with CI-friendly output.
 - [jest-angular-test-verifier](https://github.com/Neizan93/jest-angular-test-verifier) Ensures that essential Angular files have corresponding test files, reporting any missed opportunities and celebrating when all is well.
 - [jest-slow-test-highlighter](https://github.com/Neizan93/jest-slow-test-highlighter) Highlights and reports the slowest tests in your suite, helping you identify areas for performance optimization.
+- [jest-wip-reporter](https://github.com/kevinrutherford/jest-wip-reporter) Classifies all tests as either passing, failing, or work-in-progress; also quiet progress reporting with dots by default.
 
 ### Results Processors
 


### PR DESCRIPTION
Given a failing test that is marked with `it.failing`, the standard Jest reporters will report such a test in exactly the same way as if it were passing. This can make it difficult to see at a glance which tests still need work.

Instead, the `jest-wip-reporter` classifies any `.failing`, `.skip` or `.todo` test as "work in progress", clearly reporting that such tests are not yet completely developed. At the end of the test run the reporter provides a list of those tests that are still work-in-progress.