### PR TITLE
add `@tsdoc-test-reporter/jest` to list of reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@
 - [jest-angular-test-verifier](https://github.com/Neizan93/jest-angular-test-verifier) Ensures that essential Angular files have corresponding test files, reporting any missed opportunities and celebrating when all is well.
 - [jest-slow-test-highlighter](https://github.com/Neizan93/jest-slow-test-highlighter) Highlights and reports the slowest tests in your suite, helping you identify areas for performance optimization.
 - [jest-wip-reporter](https://github.com/kevinrutherford/jest-wip-reporter) Classifies all tests as either passing, failing, or work-in-progress; also quiet progress reporting with dots by default.
+- [@tsdoc-test-reporter/jest](https://github.com/tsdoc-test-reporter/reporter) A reporter that attaches JS/TSDoc comments to your test results and generates a summary in HTML or JSON.
 
 ### Results Processors
 


### PR DESCRIPTION
`@tsdoc-test-reporter/jest` is a test reporter that attaches JS/TSDoc comments to your test results. It is mainly used to generate a summary in HTML but can also output JSON. Enabling you to add metadata to your test results.

Reporter:
https://github.com/tsdoc-test-reporter/reporter

Example output:
https://tsdoc-test-reporter.github.io/kitchen-sink/