### PR TITLE
add link to vscode-jest-runner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 ### IDE
 
 - [vscode-jest](https://github.com/jest-community/vscode-jest) Works out of the box Jest based testing in VS Code.
+- [vscode-jest-runner](https://github.com/firsttris/vscode-jest-runner) Simple way to run or debug one or more tests from context menu, codelens or command plalette.
 - [wallaby](https://github.com/wallabyjs/public) The pinnacle of the idea of a test runner integrated into an editor.
 - [coc-jest](https://github.com/neoclide/coc-jest) Jest plugin for [coc.nvim](https://github.com/neoclide/coc.nvim).
 - [jester](https://github.com/David-Kunz/jester) A Neovim plugin to easily run and debug Jest tests.


### PR DESCRIPTION
Hey,

here is a link to my vscode extension: [vscode-jest-runner](https://github.com/firsttris/vscode-jest-runner) 

[vscode-jest-runner](https://github.com/firsttris/vscode-jest-runner)  offers a simple way to run or debug one or more tests from context menu, codelens or command plalette.

While [vscode-jest](https://github.com/jest-community/vscode-jest) is running your current test-suite everytime you change it, [vscode-jest-runner](https://github.com/firsttris/vscode-jest-runner) is focused on running or debugging a specific test or test-suite.

Recently vscode-jest-runner reached over 1M  installs on [Visual-Studio-Marketplace](https://marketplace.visualstudio.com/items?itemName=firsttris.vscode-jest-runner).

[Since 2020](https://github.com/nrwl/nx/issues/3868) vscode-jest-runner will be installed as a recommended extension by everyone wo uses [NX](https://nx.dev/) to create their project.

I have also worked on [jest-editor-support](https://github.com/jest-community/jest-editor-support/pull/30) which is used by vscode-jest and vscode-jest-runner. Thats why i put the link directly under vscode-jest.

Let me know if i should change something.
Would be happy if you add my link!

best regards
Tristan



