### PR TITLE
add `@geek-fun/jest-search` to list of Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@
 - [jest-puppeteer](https://github.com/smooth-code/jest-puppeteer) A Jest preset that enables a ready-to-use environment to write integration tests using Puppeteer.
 - [jest-preset-angular](https://github.com/thymikee/jest-preset-angular) Jest preset for [Angular](https://angular.io) projects.
 - [jest-preset-gatsby](https://github.com/keplersj/jest-preset-gatsby) Jest preset to streamline unit testing a Gatsby project.
-- [jest-search](https://github.com/geek-fun/jest-search) Jest preset for working with customisable version of  OpenSearch, ElasticSearch and ZincSearch
+- [jest-search](https://github.com/geek-fun/jest-search) Jest preset for working with customisable version of OpenSearch, ElasticSearch and ZincSearch.
 
 ### Generators
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@
 - [jest-puppeteer](https://github.com/smooth-code/jest-puppeteer) A Jest preset that enables a ready-to-use environment to write integration tests using Puppeteer.
 - [jest-preset-angular](https://github.com/thymikee/jest-preset-angular) Jest preset for [Angular](https://angular.io) projects.
 - [jest-preset-gatsby](https://github.com/keplersj/jest-preset-gatsby) Jest preset to streamline unit testing a Gatsby project.
+- [jest-search](https://github.com/geek-fun/jest-search) Jest preset for working with customisable version of  OpenSearch, ElasticSearch and ZincSearch
 
 ### Generators
 


### PR DESCRIPTION
`@geek-fun/jest-search` is a Presets like `jest-elasticsearch`, but it also enable the support for OpenSearch and ZincSearch, it also support specify the version of search eingine in config file rather than folk and build its own package,
and more it also export functions to start and stop engine so user can not only setup environment through Presets globally but also can make it run in specific test only


jest-search:
https://github.com/geek-fun/jest-search