### PR TITLE
feat: add jest-console-group-reporter to reporter list

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
 - [jest-wip-reporter](https://github.com/kevinrutherford/jest-wip-reporter) Classifies all tests as either passing, failing, or work-in-progress; also quiet progress reporting with dots by default.
 - [@tsdoc-test-reporter/jest](https://github.com/tsdoc-test-reporter/reporter) A reporter that attaches JS/TSDoc comments to your test results and generates a summary in HTML or JSON.
 - [testomatio-jest-reporter](https://github.com/testomatio/reporter/blob/master/docs/frameworks.md#Jest) Allows to analyze Jest autotests, collect test metadata and report them to the testomat.io TCM system.
+- [jest-console-group-reporter](https://github.com/Ashvin-Pal/jest-console-group-reporter) Automatically groups console messages, allows filtering, and provides flexible display configuration options.
 
 ### Results Processors
 


### PR DESCRIPTION
![image](https://github.com/jest-community/awesome-jest/assets/56989405/c5c1fb77-c5cc-49e8-90be-56740fda237c)


A Jest reporter designed to enhance readability and organization of console messages. It automatically groups console messages, reducing clutter and making it easier to interpret large volumes of output. Additionally, it integrates seamlessly with GitHub Actions, ensuring clean and concise message display. This reporter is particularly useful for projects with extensive console messages, as it turns repetitive console messages into a neatly structured overview.