### PR TITLE
Add `echoed` to list of Reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@
 - [@tsdoc-test-reporter/jest](https://github.com/tsdoc-test-reporter/reporter) A reporter that attaches JS/TSDoc comments to your test results and generates a summary in HTML or JSON.
 - [testomatio-jest-reporter](https://github.com/testomatio/reporter/blob/master/docs/frameworks.md#Jest) Allows to analyze Jest autotests, collect test metadata and report them to the testomat.io TCM system.
 - [jest-console-group-reporter](https://github.com/Ashvin-Pal/jest-console-group-reporter) Automatically groups console messages, allows filtering, and provides flexible display configuration options.
+- [echoed](https://github.com/mrasu/echoed) Makes tests observable by reporting OpenTelemetry data.
 
 ### Results Processors
 


### PR DESCRIPTION
`Echoed` collects OpenTelemetry's data to visualize requests made from Jest tests and makes it easy to investigate failing tests.

![](https://raw.githubusercontent.com/mrasu/echoed/main/docs/img/howEchoedWorks.png)