### PR TITLE
Add devcontainer config with GitHub CLI feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "name": "awesome-jest",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  }
+}


### PR DESCRIPTION
## Why
This adds a ready-to-use devcontainer setup so contributors can immediately use `gh` inside the container without extra manual installation.

## What changed
- Added `.devcontainer/devcontainer.json`
- Set a Node 22 devcontainer base image
- Enabled the `ghcr.io/devcontainers/features/github-cli:1` feature

## Notes
This is a minimal initial devcontainer config focused on enabling GitHub CLI support.